### PR TITLE
feat: access to defined scope

### DIFF
--- a/docs/src/content/docs/core/scoped-di.mdx
+++ b/docs/src/content/docs/core/scoped-di.mdx
@@ -65,17 +65,14 @@ runApp(
   MaterialApp(
     home: Scaffold(
       body: ProviderScope(
-        providers: [numberProvider],
-        child: ProviderScope(
-          providers: [doubleNumberPlusArgProvider(10)],
-          child: Builder(
+        providers: [numberProvider, doubleNumberPlusArgProvider(10)],
+        child: Builder(
             builder: (context) {
               final number = numberProvider.of(context);
               final doubleNumberPlusArg = doubleNumberPlusArgProvider.of(context);
               return Text('$number $doubleNumberPlusArg');
             },
           ),
-        ),
       ),
     ),
   ),
@@ -96,15 +93,16 @@ This is because `doubleNumberPlusArgProvider` uses the context to find the value
 ```dart
 // bad example
 ProviderScope(
-  providers: [
-    numberProvider,
-    doubleNumberPlusArgProvider(10),
-  ],
-  child: // ...
+  providers: [doubleNumberPlusArgProvider(10)],
+  child: ProviderScope(
+    providers: [numberProvider],
+    child: // ...
+  ),
 )
 ```
 
-Placing the `ProviderScope` containing `doubleNumberPlusArgProvider` above the one containing `numberProvider` would also not work. It needs to be like in the full example above.
+Placing the `ProviderScope` containing `doubleNumberPlusArgProvider` above the one containing `numberProvider` does not work.
+It needs to be like in the full example above.
 
 ## Graphical representation
 

--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- **FEAT**: Allow providers to access the scope where they are defined.
+
 ## 1.0.0+1
 
 - **CHORE**: Update README.md

--- a/packages/disco/lib/src/models/providers/instantiable_provider.dart
+++ b/packages/disco/lib/src/models/providers/instantiable_provider.dart
@@ -2,6 +2,5 @@ part of '../../disco_internal.dart';
 
 /// Either a [Provider] or an [InstantiableArgProvider] (i.e. an [ArgProvider]
 /// with its argument).
-sealed class InstantiableProvider {
-  InstantiableProvider._();
-}
+@immutable
+sealed class InstantiableProvider {}

--- a/packages/disco/lib/src/models/providers/instantiable_provider.dart
+++ b/packages/disco/lib/src/models/providers/instantiable_provider.dart
@@ -2,7 +2,6 @@ part of '../../disco_internal.dart';
 
 /// Either a [Provider] or an [InstantiableArgProvider] (i.e. an [ArgProvider]
 /// with its argument).
-@immutable
 sealed class InstantiableProvider {
   InstantiableProvider._();
 }

--- a/packages/disco/lib/src/models/providers/provider.dart
+++ b/packages/disco/lib/src/models/providers/provider.dart
@@ -37,8 +37,7 @@ class Provider<T extends Object> extends InstantiableProvider {
     bool? lazy,
   })  : _createValue = create,
         _disposeValue = dispose,
-        _lazy = lazy ?? DiscoConfig.lazy,
-        super._();
+        _lazy = lazy ?? DiscoConfig.lazy;
 
   /// {@macro arg-provider}
   static ArgProvider<T, A> withArgument<T extends Object, A>(
@@ -115,9 +114,14 @@ class Provider<T extends Object> extends InstantiableProvider {
     _disposeValue?.call(value as T);
   }
 
-  // cannot be late
-  // ignore: use_late_for_private_fields_and_variables
-  ProviderScopeState? _scopeState;
+  // This map is used to store the state of the provider for each scope.
+  // It is not a variable to keep the class immutable.
+  final Map<String, ProviderScopeState?> __scopeStateMap = {};
+
+  ProviderScopeState? get _scopeState => __scopeStateMap['scope'];
+  set _scopeState(ProviderScopeState? value) {
+    __scopeStateMap['scope'] = value;
+  }
 
   /// Returns the type of the value.
   Type get _valueType => T;

--- a/packages/disco/lib/src/models/providers/provider.dart
+++ b/packages/disco/lib/src/models/providers/provider.dart
@@ -61,7 +61,7 @@ class Provider<T extends Object> extends InstantiableProvider {
   /// {@template Provider.create}
   /// The function called to create the element.
   /// {@endtemplate}
-  late final CreateProviderValueFn<T> _createValue;
+  final CreateProviderValueFn<T> _createValue;
 
   /// {@template Provider.dispose}
   /// An optional dispose function called when the [ProviderScope] that created

--- a/packages/disco/lib/src/models/providers/provider.dart
+++ b/packages/disco/lib/src/models/providers/provider.dart
@@ -120,6 +120,8 @@ class Provider<T extends Object> extends InstantiableProvider {
     _disposeValue?.call(value as T);
   }
 
+  // cannot be late
+  // ignore: use_late_for_private_fields_and_variables
   ProviderScopeState? _scopeState;
 
   /// Returns the type of the value.

--- a/packages/disco/lib/src/models/providers/provider.dart
+++ b/packages/disco/lib/src/models/providers/provider.dart
@@ -35,14 +35,10 @@ class Provider<T extends Object> extends InstantiableProvider {
 
     /// {@macro Provider.lazy}
     bool? lazy,
-  })  : _disposeValue = dispose,
+  })  : _createValue = create,
+        _disposeValue = dispose,
         _lazy = lazy ?? DiscoConfig.lazy,
-        super._() {
-    _createValue = (context, scopeState) {
-      _scopeState = scopeState;
-      return create(context);
-    };
-  }
+        super._();
 
   /// {@macro arg-provider}
   static ArgProvider<T, A> withArgument<T extends Object, A>(
@@ -65,8 +61,7 @@ class Provider<T extends Object> extends InstantiableProvider {
   /// {@template Provider.create}
   /// The function called to create the element.
   /// {@endtemplate}
-  late final T Function(BuildContext context, ProviderScopeState scopeState)
-      _createValue;
+  late final CreateProviderValueFn<T> _createValue;
 
   /// {@template Provider.dispose}
   /// An optional dispose function called when the [ProviderScope] that created

--- a/packages/disco/lib/src/models/providers/provider_argument.dart
+++ b/packages/disco/lib/src/models/providers/provider_argument.dart
@@ -29,9 +29,14 @@ class ArgProvider<T extends Object, A> {
   /// {@macro Provider.dispose}
   final DisposeProviderValueFn<T>? _disposeValue;
 
-  // cannot be late
-  // ignore: use_late_for_private_fields_and_variables
-  ProviderScopeState? _scopeState;
+// This map is used to store the state of the provider for each scope.
+  // It is not a variable to keep the class immutable.
+  final Map<String, ProviderScopeState?> __scopeStateMap = {};
+
+  ProviderScopeState? get _scopeState => __scopeStateMap['scope'];
+  set _scopeState(ProviderScopeState? value) {
+    __scopeStateMap['scope'] = value;
+  }
 
   // ---
   // Overrides
@@ -95,7 +100,7 @@ class ArgProvider<T extends Object, A> {
 class InstantiableArgProvider<T extends Object, A>
     extends InstantiableProvider {
   /// {@macro InstantiableArgProvider}
-  InstantiableArgProvider._(this._argProvider, this._arg) : super._();
+  InstantiableArgProvider._(this._argProvider, this._arg);
   final ArgProvider<T, A> _argProvider;
   final A _arg;
 }

--- a/packages/disco/lib/src/models/providers/provider_argument.dart
+++ b/packages/disco/lib/src/models/providers/provider_argument.dart
@@ -10,7 +10,6 @@ typedef CreateArgProviderValueFn<T, A> = T Function(
 /// A [Provider] that needs to be given an initial argument before
 /// it can be used.
 /// {@endtemplate}
-@immutable
 class ArgProvider<T extends Object, A> {
   /// {@macro ArgProvider}
   ArgProvider._(
@@ -29,6 +28,10 @@ class ArgProvider<T extends Object, A> {
 
   /// {@macro Provider.dispose}
   final DisposeProviderValueFn<T>? _disposeValue;
+
+  // cannot be late
+  // ignore: use_late_for_private_fields_and_variables
+  ProviderScopeState? _scopeState;
 
   // ---
   // Overrides

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -52,6 +52,11 @@ class ProviderScope extends StatefulWidget {
       if (state.isProviderInScope(id)) return state;
     }
 
+    // try to find the provider in the scope where it was defined
+    if (id._scopeState != null && id._scopeState!.isProviderInScope(id)) {
+      return id._scopeState;
+    }
+
     return _InheritedProvider.inheritFromNearest(context, id, null)?.state;
   }
 
@@ -168,7 +173,7 @@ class ProviderScopeState extends State<ProviderScope> {
         // create non lazy providers.
         if (!provider._lazy) {
           // create and store the provider
-          createdProviderValues[id] = provider._createValue(context);
+          createdProviderValues[id] = provider._createValue(context, this);
         }
       }
 
@@ -203,7 +208,7 @@ class ProviderScopeState extends State<ProviderScope> {
           final intermediateId = allArgProvidersInScope[id]!;
           // create and store the provider
           createdProviderValues[intermediateId] =
-              allArgProvidersInScope[id]!._createValue(context);
+              allArgProvidersInScope[id]!._createValue(context, this);
         }
       }
     } else if (widget.overrides != null) {
@@ -237,7 +242,7 @@ class ProviderScopeState extends State<ProviderScope> {
         {
           // create and store the provider
           createdProviderValues[id] =
-              allProvidersInScope[id]!._createValue(context);
+              allProvidersInScope[id]!._createValue(context, this);
         }
       }
 
@@ -273,7 +278,7 @@ class ProviderScopeState extends State<ProviderScope> {
           final intermediateId = allArgProvidersInScope[id]!;
           // create and store the provider
           createdProviderValues[intermediateId] =
-              allArgProvidersInScope[id]!._createValue(context);
+              allArgProvidersInScope[id]!._createValue(context, this);
         }
       }
     }
@@ -304,7 +309,7 @@ class ProviderScopeState extends State<ProviderScope> {
     // find the intermediate provider in the list
     final provider = getIntermediateProvider(id)!;
     // create and return its value
-    final value = provider._createValue(context);
+    final value = provider._createValue(context, this);
     // store the created provider value
     createdProviderValues[id] = value;
     return value;
@@ -333,7 +338,7 @@ class ProviderScopeState extends State<ProviderScope> {
     // find the intermediate provider in the list
     final provider = getIntermediateProviderForArgProvider(id)!;
     // create and return its value
-    final value = provider._createValue(context);
+    final value = provider._createValue(context, this);
     // store the created provider value
     createdProviderValues[allArgProvidersInScope[id]!] = value;
     return value;

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -297,6 +297,18 @@ class ProviderScopeState extends State<ProviderScope> {
     super.dispose();
   }
 
+  @override
+  void deactivate() {
+    // Reset the scope state of all providers when the widget is deactivated.
+    //
+    // This is useful, for example, when the key of the [ProviderScope] changes.
+    for (final provider in allProvidersInScope.values) {
+      provider._scopeState = null;
+    }
+
+    super.deactivate();
+  }
+
   // Providers logic ----------------------------------------------------------
 
   /// Tries to find the intermediate [Provider] associated with this [id].

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -165,7 +165,7 @@ class ProviderScopeState extends State<ProviderScope> {
         // NB: even though `id` and `provider` point to the same reference,
         // two different variables are used to simplify understanding how
         // providers are saved.
-        final id = provider;
+        final id = provider.._scopeState = this;
 
         // In this case, the provider put in scope can be the ID itself.
         allProvidersInScope[id] = provider;
@@ -173,7 +173,7 @@ class ProviderScopeState extends State<ProviderScope> {
         // create non lazy providers.
         if (!provider._lazy) {
           // create and store the provider
-          createdProviderValues[id] = provider._createValue(context, this);
+          createdProviderValues[id] = provider._createValue(context);
         }
       }
 
@@ -205,10 +205,11 @@ class ProviderScopeState extends State<ProviderScope> {
         if (!instantiableArgProvider._argProvider._lazy) {
           // the intermediate ID is a reference to the associated generated
           // intermediate provider
-          final intermediateId = allArgProvidersInScope[id]!;
+          final intermediateId = allArgProvidersInScope[id]!
+            .._scopeState = this;
           // create and store the provider
           createdProviderValues[intermediateId] =
-              allArgProvidersInScope[id]!._createValue(context, this);
+              allArgProvidersInScope[id]!._createValue(context);
         }
       }
     } else if (widget.overrides != null) {
@@ -234,7 +235,7 @@ class ProviderScopeState extends State<ProviderScope> {
       );
 
       for (final override in providerOverrides) {
-        final id = override._provider;
+        final id = override._provider.._scopeState = this;
 
         allProvidersInScope[id] = override._generateIntermediateProvider();
 
@@ -242,7 +243,7 @@ class ProviderScopeState extends State<ProviderScope> {
         {
           // create and store the provider
           createdProviderValues[id] =
-              allProvidersInScope[id]!._createValue(context, this);
+              allProvidersInScope[id]!._createValue(context);
         }
       }
 
@@ -272,14 +273,12 @@ class ProviderScopeState extends State<ProviderScope> {
         allArgProvidersInScope[id] = override._generateIntermediateProvider();
 
         // create providers (they are never lazy in the case of overrides)
-        {
-          // the intermediate ID is a reference to the associated generated
-          // intermediate provider
-          final intermediateId = allArgProvidersInScope[id]!;
-          // create and store the provider
-          createdProviderValues[intermediateId] =
-              allArgProvidersInScope[id]!._createValue(context, this);
-        }
+        // the intermediate ID is a reference to the associated generated
+        // intermediate provider
+        final intermediateId = allArgProvidersInScope[id]!.._scopeState = this;
+        // create and store the provider
+        createdProviderValues[intermediateId] =
+            allArgProvidersInScope[id]!._createValue(context);
       }
     }
   }
@@ -319,9 +318,9 @@ class ProviderScopeState extends State<ProviderScope> {
   /// Creates a provider value and stores it to [createdProviderValues].
   dynamic createProviderValue(Provider id) {
     // find the intermediate provider in the list
-    final provider = getIntermediateProvider(id)!;
+    final provider = getIntermediateProvider(id)!.._scopeState = this;
     // create and return its value
-    final value = provider._createValue(context, this);
+    final value = provider._createValue(context);
     // store the created provider value
     createdProviderValues[id] = value;
     return value;
@@ -348,9 +347,10 @@ class ProviderScopeState extends State<ProviderScope> {
     ArgProvider id,
   ) {
     // find the intermediate provider in the list
-    final provider = getIntermediateProviderForArgProvider(id)!;
+    final provider = getIntermediateProviderForArgProvider(id)!
+      .._scopeState = this;
     // create and return its value
-    final value = provider._createValue(context, this);
+    final value = provider._createValue(context);
     // store the created provider value
     createdProviderValues[allArgProvidersInScope[id]!] = value;
     return value;

--- a/packages/disco/pubspec.yaml
+++ b/packages/disco/pubspec.yaml
@@ -1,6 +1,6 @@
 name: disco
 description: A Flutter library bringing a new concept of scoped providers for dependency injection, which are independent of any specific state management solution.
-version: 1.0.0+1
+version: 1.1.0+1
 repository: https://github.com/our-creativity/disco
 homepage: https://disco.mariuti.com
 documentation: https://disco.mariuti.com

--- a/packages/disco/test/disco_test.dart
+++ b/packages/disco/test/disco_test.dart
@@ -122,17 +122,15 @@ void main() {
             providers: [numberProvider, doubleNumberProvider],
             child: Builder(
               builder: (context) {
-                final number = numberProvider.of(context);
                 final doubleNumber = doubleNumberProvider.of(context);
-                return Text('$number $doubleNumber');
+                return Text('$doubleNumber');
               },
             ),
           ),
         ),
       ),
     );
-    Finder numberFinder(int value1, int value2) => find.text('$value1 $value2');
-    expect(numberFinder(5, 10), findsOneWidget);
+    expect(find.text('10'), findsOneWidget);
   });
 
   testWidgets('Test ProviderScope throws an error for a not found provider',

--- a/packages/disco/test/disco_test.dart
+++ b/packages/disco/test/disco_test.dart
@@ -132,6 +132,33 @@ void main() {
     );
     expect(find.text('10'), findsOneWidget);
   });
+  testWidgets(
+      'Test Provider.of within Provider create fn for Provider.withArgument',
+      (tester) async {
+    final numberProvider = Provider.withArgument((_, int arg) => arg);
+
+    final doubleNumberProvider = Provider.withArgument((context, int arg) {
+      final number = numberProvider.of(context);
+      return number * arg;
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProviderScope(
+            providers: [numberProvider(5), doubleNumberProvider(2)],
+            child: Builder(
+              builder: (context) {
+                final doubleNumber = doubleNumberProvider.of(context);
+                return Text('$doubleNumber');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('10'), findsOneWidget);
+  });
 
   testWidgets('Test ProviderScope throws an error for a not found provider',
       (tester) async {

--- a/packages/disco/test/disco_test.dart
+++ b/packages/disco/test/disco_test.dart
@@ -119,16 +119,13 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: ProviderScope(
-            providers: [numberProvider],
-            child: ProviderScope(
-              providers: [doubleNumberProvider],
-              child: Builder(
-                builder: (context) {
-                  final number = numberProvider.of(context);
-                  final doubleNumber = doubleNumberProvider.of(context);
-                  return Text('$number $doubleNumber');
-                },
-              ),
+            providers: [numberProvider, doubleNumberProvider],
+            child: Builder(
+              builder: (context) {
+                final number = numberProvider.of(context);
+                final doubleNumber = doubleNumberProvider.of(context);
+                return Text('$number $doubleNumber');
+              },
             ),
           ),
         ),


### PR DESCRIPTION
Allow providers to access the scope where they are defined.
This now it totally feasible
```dart
testWidgets('Test Provider.of within Provider create fn', (tester) async {
    final numberProvider = Provider((_) => 5);

    final doubleNumberProvider = Provider((context) {
      final number = numberProvider.of(context);
      return number * 2;
    });

    await tester.pumpWidget(
      MaterialApp(
        home: Scaffold(
          body: ProviderScope(
            providers: [numberProvider, doubleNumberProvider],
            child: Builder(
              builder: (context) {
                final number = numberProvider.of(context);
                final doubleNumber = doubleNumberProvider.of(context);
                return Text('$number $doubleNumber');
              },
            ),
          ),
        ),
      ),
    );
    Finder numberFinder(int value1, int value2) => find.text('$value1 $value2');
    expect(numberFinder(5, 10), findsOneWidget);
  });
```

This removes the boilerplate of using two nested ProviderScope widgets