### PR TITLE
feat: add ProviderScopes

### DIFF
--- a/packages/disco/lib/src/disco_internal.dart
+++ b/packages/disco/lib/src/disco_internal.dart
@@ -13,3 +13,4 @@ part 'utils/disco_config.dart';
 part 'widgets/provider_scope.dart';
 part 'widgets/provider_scope_override.dart';
 part 'widgets/provider_scope_portal.dart';
+part 'widgets/provider_scopes.dart';

--- a/packages/disco/lib/src/widgets/provider_scopes.dart
+++ b/packages/disco/lib/src/widgets/provider_scopes.dart
@@ -1,0 +1,40 @@
+part of '../disco_internal.dart';
+
+class ProviderScopes extends StatefulWidget {
+  ProviderScopes({
+    required this.child,
+    required this.providers,
+    super.key,
+  });
+
+  /// {@template ProviderScope.child}
+  /// The widget child that gets access to the [providers].
+  /// {@endtemplate}
+  final Widget child;
+
+  /// All the providers provided to all the descendants of [ProviderScope].
+  final List<List<InstantiableProvider>> providers;
+
+  @override
+  State<ProviderScopes> createState() => _ProviderScopesState();
+}
+
+class _ProviderScopesState extends State<ProviderScopes> {
+  late final Widget nested;
+
+  @override
+  void initState() {
+    super.initState();
+    var widgetToDisplay = widget.child;
+
+    for (final providersInCurrentScope in widget.providers.reversed) {
+      widgetToDisplay = ProviderScope(
+          providers: providersInCurrentScope, child: widgetToDisplay);
+    }
+
+    nested = widgetToDisplay;
+  }
+
+  @override
+  Widget build(BuildContext context) => nested;
+}

--- a/packages/disco/test/disco_test.dart
+++ b/packages/disco/test/disco_test.dart
@@ -108,27 +108,30 @@ void main() {
   });
 
   testWidgets('Test Provider.of within Provider create fn', (tester) async {
-    final numberProvider = Provider((_) => 5);
+    final numberProvider = Provider((_) => 5, lazy: false);
 
-    final doubleNumberProvider = Provider((context) {
-      final number = numberProvider.of(context);
-      return number * 2;
-    });
+    final doubleNumberProvider = Provider(
+      (context) {
+        final number = numberProvider.of(context);
+        return number * 2;
+      },
+      lazy: false,
+    );
 
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: ProviderScope(
-            providers: [numberProvider],
-            child: ProviderScope(
-              providers: [doubleNumberProvider],
-              child: Builder(
-                builder: (context) {
-                  final number = numberProvider.of(context);
-                  final doubleNumber = doubleNumberProvider.of(context);
-                  return Text('$number $doubleNumber');
-                },
-              ),
+          body: ProviderScopes(
+            providers: [
+              [numberProvider],
+              [doubleNumberProvider],
+            ],
+            child: Builder(
+              builder: (context) {
+                final number = numberProvider.of(context);
+                final doubleNumber = doubleNumberProvider.of(context);
+                return Text('$number $doubleNumber');
+              },
             ),
           ),
         ),


### PR DESCRIPTION
Currently the other PR (https://github.com/our-creativity/disco/pull/17) has some problems: circular dependencies and it is not tested with some provider reusage in different, coexisting subtrees (at the moment it clearly introduces bugs).

This PR does not present the above problems (and in generally it shouldn't introduce new ones, since `ProviderScopes` uses `ProviderScope` internally without changing the existing code).

`ProviderScopes` offers a similar API but allows multiple scopes at once. Here is how it looks like:

```dart
ProviderScopes(
  providers: [
    [numberProvider], # each list represents a scope
    [doubleNumberProvider],
  ],
  child: Builder(
    builder: (context) {
      final number = numberProvider.of(context);
      final doubleNumber = doubleNumberProvider.of(context);
      return Text('$number $doubleNumber');
    },
  ),
),
```