### PR TITLE
fix: provider scopes inside provider scope portal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "example",
+      "cwd": "packages/disco/example",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "auto_route",
+      "cwd": "examples/auto_route",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "bloc",
+      "cwd": "examples/bloc",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "preferences",
+      "cwd": "examples/preferences",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "solidart",
+      "cwd": "examples/solidart",
+      "request": "launch",
+      "type": "dart"
+    },
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,6 @@
       "cwd": "examples/solidart",
       "request": "launch",
       "type": "dart"
-    },
+    }
   ]
 }

--- a/docs/src/content/docs/examples/solidart.mdx
+++ b/docs/src/content/docs/examples/solidart.mdx
@@ -101,7 +101,7 @@ The `TodosController` can have an initialValue, that is the initial list of todo
 ```dart title=controllers/todos.dart
 import 'package:disco/disco.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_solidart/flutter_solidart.dart' hide Provider;
+import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solidart_example/domain/todo.dart';
 
 /// The todos controller provider
@@ -213,7 +213,7 @@ The `TodosBody` is the body of our feature, it has a text input on top where you
 ```dart title=widgets/todos_body.dart
 import 'package:disco/disco.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart' hide Provider;
+import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solidart_example/controllers/todos.dart';
 import 'package:solidart_example/domain/todo.dart';
 import 'package:solidart_example/widgets/todos_list.dart';

--- a/docs/src/content/docs/examples/solidart.mdx
+++ b/docs/src/content/docs/examples/solidart.mdx
@@ -15,7 +15,7 @@ This is the `flutter_solidart` version used in this example:
 
 ```yaml {2}
 dependencies:
-  flutter_solidart: ^2.0.0-dev.2
+  flutter_solidart: ^2.0.0
 ```
 
 This example leverages the power of the `ProviderScope` widget using providers.

--- a/examples/auto_route/pubspec.yaml
+++ b/examples/auto_route/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   auto_route_generator: ^9.3.1
   build_runner: ^2.4.14
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^9.0.0
 
 flutter:
   uses-material-design: true

--- a/examples/bloc/pubspec.yaml
+++ b/examples/bloc/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^9.0.0
 
 flutter:
   uses-material-design: true

--- a/examples/solidart/lib/controllers/todos.dart
+++ b/examples/solidart/lib/controllers/todos.dart
@@ -1,6 +1,6 @@
 import 'package:disco/disco.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_solidart/flutter_solidart.dart' hide Provider;
+import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solidart_example/domain/todo.dart';
 
 final todosControllerProvider = Provider<TodosController>(

--- a/examples/solidart/lib/widgets/todos_body.dart
+++ b/examples/solidart/lib/widgets/todos_body.dart
@@ -1,6 +1,6 @@
 import 'package:disco/disco.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart' hide Provider;
+import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solidart_example/controllers/todos.dart';
 import 'package:solidart_example/domain/todo.dart';
 import 'package:solidart_example/widgets/todos_list.dart';

--- a/examples/solidart/pubspec.yaml
+++ b/examples/solidart/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
     path: ../../packages/disco
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.0.0-dev.2
+  flutter_solidart: ^2.0.0
   uuid: ^4.5.1
 
 dev_dependencies:
-  custom_lint: ^0.6.10
+  custom_lint: ^0.7.0
   flutter_test:
     sdk: flutter
-  solidart_lint: ^2.0.0-dev.2
-  very_good_analysis: ^7.0.0
+  solidart_lint: ^2.0.0
+  very_good_analysis: ^9.0.0
 
 dependency_overrides:
   dart_style: ^3.0.1

--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- **FIX**: A bug prevented users to inject providers inside a `ProviderScope` which was placed inside a `ProviderScopePortal`.
+
 ## 1.0.0+1
 
 - **CHORE**: Update README.md

--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-- **FIX**: A bug prevented users to inject providers inside a `ProviderScope` which was placed inside a `ProviderScopePortal`.
+- **FIX**: A bug prevented users to inject providers from a `ProviderScope` which was placed inside a `ProviderScopePortal`.
 
 ## 1.0.0+1
 

--- a/packages/disco/example/pubspec.yaml
+++ b/packages/disco/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^9.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -71,7 +71,7 @@ class ProviderScope extends StatefulWidget {
   }) {
     // Try to find the provider in the current widget tree.
     var state = _findState<T>(context, id: id);
-    // If the state has not been found yet, try to find by using the
+    // If the state has not been found yet, try to find it by using the
     // ProviderScopePortal context.
     if (state == null) {
       final providerScopePortalContext = ProviderScopePortal._maybeOf(context);

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -69,10 +69,13 @@ class ProviderScope extends StatefulWidget {
     BuildContext context, {
     required Provider<T> id,
   }) {
-    // If there is a ProviderValue ancestor, use it as the context
+    var state = _findState<T>(context, id: id);
+    // If there is a ProviderScopePortal ancestor and the state is not found,
+    // try to find the state in the main context.
     final providerScopePortalContext = ProviderScopePortal._maybeOf(context);
-    final effectiveContext = providerScopePortalContext ?? context;
-    final state = _findState<T>(effectiveContext, id: id);
+    if (state == null && providerScopePortalContext != null) {
+      state = _findState<T>(providerScopePortalContext, id: id);
+    }
     if (state == null) return null;
     final createdProvider = state.createdProviderValues[id];
     if (createdProvider != null) return createdProvider as T;

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -69,12 +69,15 @@ class ProviderScope extends StatefulWidget {
     BuildContext context, {
     required Provider<T> id,
   }) {
+    // Try to find the provider in the current widget tree.
     var state = _findState<T>(context, id: id);
-    // If there is a ProviderScopePortal ancestor and the state is not found,
-    // try to find the state in the main context.
-    final providerScopePortalContext = ProviderScopePortal._maybeOf(context);
-    if (state == null && providerScopePortalContext != null) {
-      state = _findState<T>(providerScopePortalContext, id: id);
+    // If the state has not been found yet, try to find by using the
+    // ProviderScopePortal context.
+    if (state == null) {
+      final providerScopePortalContext = ProviderScopePortal._maybeOf(context);
+      if (providerScopePortalContext != null) {
+        state = _findState<T>(providerScopePortalContext, id: id);
+      }
     }
     if (state == null) return null;
     final createdProvider = state.createdProviderValues[id];

--- a/packages/disco/pubspec.yaml
+++ b/packages/disco/pubspec.yaml
@@ -1,6 +1,6 @@
 name: disco
 description: A Flutter library bringing a new concept of scoped providers for dependency injection, which are independent of any specific state management solution.
-version: 1.0.0+1
+version: 1.0.1
 repository: https://github.com/our-creativity/disco
 homepage: https://disco.mariuti.com
 documentation: https://disco.mariuti.com
@@ -23,4 +23,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.5
-  very_good_analysis: ^7.0.0
+  very_good_analysis: ^9.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,3 +9,6 @@ workspace:
   - examples/bloc
   - examples/solidart
   - examples/preferences
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Visual Studio Code launch configurations for easier Dart debugging across multiple example projects.
  * Enabled Material Design support in the Flutter project.

* **Bug Fixes**
  * Fixed an issue where providers could not be injected from a nested ProviderScope inside a ProviderScopePortal.

* **Documentation**
  * Updated example documentation and code snippets to reference stable versions of dependencies and adjust import statements accordingly.

* **Tests**
  * Added a widget test to verify correct provider access when nesting ProviderScope inside ProviderScopePortal.

* **Chores**
  * Upgraded various dependencies to their latest stable versions across multiple example and package projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->