### PR TITLE
fix/22

### DIFF
--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- **FIX**: A bug prevented users to inject providers with arguments from a `ProviderScope` which was placed inside a `ProviderScopePortal`.
+
 ## 1.0.1
 
 - **FIX**: A bug prevented users to inject providers from a `ProviderScope` which was placed inside a `ProviderScopePortal`.

--- a/packages/disco/lib/src/widgets/provider_scope.dart
+++ b/packages/disco/lib/src/widgets/provider_scope.dart
@@ -106,10 +106,17 @@ class ProviderScope extends StatefulWidget {
     BuildContext context, {
     required ArgProvider<T, A> id,
   }) {
-    // If there is a ProviderValue ancestor, use it as the context
-    final providerScopePortalContext = ProviderScopePortal._maybeOf(context);
-    final effectiveContext = providerScopePortalContext ?? context;
-    final state = _findStateForArgProvider<T, A>(effectiveContext, id: id);
+    // Try to find the provider in the current widget tree.
+    var state = _findStateForArgProvider<T, A>(context, id: id);
+    // If the state has not been found yet, try to find it by using the
+    // ProviderScopePortal context.
+    if (state == null) {
+      final providerScopePortalContext = ProviderScopePortal._maybeOf(context);
+      if (providerScopePortalContext != null) {
+        state =
+            _findStateForArgProvider<T, A>(providerScopePortalContext, id: id);
+      }
+    }
     if (state == null) return null;
     final providerAsId = state.allArgProvidersInScope[id];
     final createdProvider = state.createdProviderValues[providerAsId];

--- a/packages/disco/pubspec.yaml
+++ b/packages/disco/pubspec.yaml
@@ -1,6 +1,6 @@
 name: disco
 description: A Flutter library bringing a new concept of scoped providers for dependency injection, which are independent of any specific state management solution.
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/our-creativity/disco
 homepage: https://disco.mariuti.com
 documentation: https://disco.mariuti.com

--- a/packages/disco/test/disco_test.dart
+++ b/packages/disco/test/disco_test.dart
@@ -437,6 +437,9 @@ void main() {
       (_) => const NumberContainer(2),
     );
 
+    final doubleCountProvider =
+        Provider.withArgument((context, int arg) => arg * 2);
+
     Future<void> showNumberDialog({required BuildContext context}) {
       return showDialog(
         context: context,
@@ -444,15 +447,19 @@ void main() {
           return ProviderScopePortal(
             mainContext: context,
             child: ProviderScope(
-              providers: [secondNumberContainerProvider],
+              providers: [
+                secondNumberContainerProvider,
+                doubleCountProvider(3),
+              ],
               child: Builder(
                 builder: (innerContext) {
                   final numberContainer =
                       numberContainerProvider.of(innerContext);
                   final secondNumberContainer =
                       secondNumberContainerProvider.of(innerContext);
+                  final doubleCount = doubleCountProvider.of(innerContext);
                   return Text(
-                    '${numberContainer.number} ${secondNumberContainer.number}',
+                    '''${numberContainer.number} ${secondNumberContainer.number} $doubleCount''',
                   );
                 },
               ),
@@ -481,14 +488,15 @@ void main() {
         ),
       ),
     );
-    Finder number2Finder(int value, int value2) => find.text('$value $value2');
+    Finder number3Finder(int value, int value2, int value3) =>
+        find.text('$value $value2 $value3');
 
     final buttonFinder = find.text('show dialog');
     expect(buttonFinder, findsOneWidget);
     await tester.tap(buttonFinder);
     await tester.pumpAndSettle();
 
-    expect(number2Finder(1, 2), findsOneWidget);
+    expect(number3Finder(1, 2, 6), findsOneWidget);
   });
 
   testWidgets('Test key change in ProviderScope (with Provider)',


### PR DESCRIPTION
closes #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where injecting providers with arguments from a nested ProviderScope inside a ProviderScopePortal did not work as expected.

* **Tests**
  * Enhanced tests to verify correct behavior when injecting providers with arguments in nested ProviderScopes.

* **Documentation**
  * Updated the changelog to reflect the latest bug fix.

* **Chores**
  * Bumped the package version to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->