### PR TITLE
chore: fix automatic deployment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # tag-pattern on pub.dev: 'v{{version}}'
+      - "v[0-9]+\\.[0-9]+\\.[0-9]+.*?" # tag-pattern on pub.dev: 'v{{version}}'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:

--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3+2
+
+- **CHORE**: Fix automatic deployment to pub.dev (GitHub workflow).
+
 ## 1.0.3+1
 
 - **CHORE**: Improve documentation.

--- a/packages/disco/README.md
+++ b/packages/disco/README.md
@@ -53,7 +53,6 @@ The package supports many features, like providers that accept arguments. But to
 
     ```dart
     class InjectingWidget extends StatelessWidget {
-
       const InjectingWidget({super.key});
 
       @override
@@ -93,7 +92,7 @@ Below is a comparison of the trade-offs between the primary provider-based depen
 | **Fallback support**                | ❌ Not available; try-catch block necessary                                        | ✅ No need                                        | ✅ `maybeOf(context)` for optional injection                      |
 | **Modal compatibility**             | ⚠️ Needs to specify all required providers one by one                  | ✅ Scoped globally, no special handling needed                                                    | ✅ Needs `ProviderPortal`, which is a portal to the main tree (all providers are available)      |
 | **API simplicity**                  | ✅ Simple                             | ⚠️ Requires learning `WidgetRef`, `ConsumerWidget`, ... | ✅ Very simple                   |
-| **Ease of integration into state management** | ❌ Requires wiring | ❌ Requires wiring   | ✅ No integration needed, works out of the box |
+| **Ease of integration into 3rd-party state management solutions** | ❌ Requires wiring | ❌ Requires wiring   | ✅ No integration needed, works out of the box |
 
 ¹ In Disco's defense regarding the **Reactivity methods included** point:
 


### PR DESCRIPTION
I added those `\\` to strictly match semantic version numbers like 1.2.3, not things like 1-2_3