### PR TITLE
chore: update changelog

### DIFF
--- a/packages/disco/CHANGELOG.md
+++ b/packages/disco/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.0.3+2
-
-- **CHORE**: Fix automatic deployment to pub.dev (GitHub workflow).
-
 ## 1.0.3+1
 
 - **CHORE**: Improve documentation.
+- **CHORE**: Fix automatic deployment to pub.dev (GitHub workflow).
 
 ## 1.0.3
 


### PR DESCRIPTION
My summary:

I deleted the two releases and tags 1.0.3+1 and 1.0.3+2 because they didn't get published correctly. The CHANGELOG needs to be updated too at this point. I think it would be easiest for people to follow the release notes if we publish 1.0.3+1 again, with the changes that got added in the meantime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the changelog by moving a deployment-related note from version 1.0.3+2 to 1.0.3+1. No other content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->